### PR TITLE
build: Remove JCenter from repository source

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,8 +3,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        // We need jcenter for the Xposed API...
-        jcenter()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:8.0.1")
@@ -20,8 +18,6 @@ allprojects {
         google()
         mavenCentral()
         maven(url = "https://api.xposed.info/")
-        // See comment in buildscript repos
-        jcenter()
     }
 }
 


### PR DESCRIPTION
This PR remove JCenter as a repository source for Gradle Build, this will allow upgrades to future Gradle versions and reduce reliance on deprecated features.

The Xposed API is available at Maven: https://mvnrepository.com/artifact/de.robv.android.xposed/api

![image](https://github.com/user-attachments/assets/584cea70-1757-41a6-b165-abaa81d0449d)
